### PR TITLE
remove detached head messages

### DIFF
--- a/src/lib/cfs.sh
+++ b/src/lib/cfs.sh
@@ -472,7 +472,7 @@ function cfs_update_git {
     cd "$TMPDIR"
     git clone "$URL" "$TMPDIR/$LAYER" || return 1
     cd "$TMPDIR/$LAYER"
-    git checkout "$GIT_TARGET" || return 1
+    git -c advice.detachedHead=false checkout "$GIT_TARGET" || return 1
 
     NEW_COMMIT=$(git rev-parse HEAD)
     if [[ "$LAYER_CUR_COMMIT" != "$NEW_COMMIT" ]]; then


### PR DESCRIPTION
this should clean up `shasta cfs update` when it moves the checkout to a tag . this option could be added to in a .gitconfig but as well but this would be much more targeted when to just when this known function is done