### PR TITLE
Adding a quiet to git clone to reduce screen scroll on cfs update

### DIFF
--- a/src/lib/cfs.sh
+++ b/src/lib/cfs.sh
@@ -470,7 +470,7 @@ function cfs_update_git {
 
     echo "cloning $LAYER_URL"
     cd "$TMPDIR"
-    git clone "$URL" "$TMPDIR/$LAYER" || return 1
+    git clone --quiet "$URL" "$TMPDIR/$LAYER" || return 1
     cd "$TMPDIR/$LAYER"
     git -c advice.detachedHead=false checkout "$GIT_TARGET" || return 1
 


### PR DESCRIPTION
this small change suppresses the object info from out of each time git clone is run. This reduces the screen scroll when updating multiple layers over multiple config files 